### PR TITLE
Add support for two intermediary certificates

### DIFF
--- a/example-github-actions-oidc.yaml
+++ b/example-github-actions-oidc.yaml
@@ -7,10 +7,10 @@ Parameters:
     Description: Arn for the GitHub OIDC Provider.
     Default: ""
     Type: String
-  GitHubOIDCThumbprint:
+  GitHubOIDCThumbprintList:
     Description: GitHub OIDC thumbprint. see also https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html
-    Default: 6938fd4d98bab03faadb97b34396831e3780aea1
-    Type: String
+    Default: "6938fd4d98bab03faadb97b34396831e3780aea1,1c58a3a8518e8759bf075b76b750d4f2df264fcd"
+    Type: CommaDelimitedList
 
 Conditions:
   CreateOIDCProvider: !Equals 
@@ -43,8 +43,7 @@ Resources:
       Url: https://token.actions.githubusercontent.com
       ClientIdList: 
         - sts.amazonaws.com
-      ThumbprintList:
-        - !Ref GitHubOIDCThumbprint
+      ThumbprintList: !Ref GitHubOIDCThumbprintList
 
 Outputs:
   Role:


### PR DESCRIPTION
2つの中間証明書を設定しないと問題が発生することがある
https://github.blog/changelog/2023-06-27-github-actions-update-on-oidc-integration-with-aws/